### PR TITLE
Fixed shrinkWrap in AnimatedListView always being false

### DIFF
--- a/lib/src/animated_listview.dart
+++ b/lib/src/animated_listview.dart
@@ -178,7 +178,7 @@ class AnimatedListView<E extends Object> extends StatelessWidget {
         keyboardDismissBehavior: keyboardDismissBehavior,
         dragStartBehavior: dragStartBehavior,
         clipBehavior: clipBehavior,
-        shrinkWrap: false,
+        shrinkWrap: shrinkWrap,
         slivers: [
           SliverPadding(
             padding: padding ?? EdgeInsets.zero,


### PR DESCRIPTION
In `animated_list_view.dart` the `shrinkWrap` property passed to `CustomScrollView` was always `false` instead of the `shrinkWrap` value passed to `AnimatedListView`. Changed the `false` keyword to `shrinkWrap` and now the Widget behaves as expected.