### PR TITLE
Fix 'null check operator used on null value' error

### DIFF
--- a/lib/src/builder/motion_animated_builder.dart
+++ b/lib/src/builder/motion_animated_builder.dart
@@ -635,6 +635,8 @@ class MotionBuilderState extends State<MotionBuilder>
     final _ActiveItem? incomingItem = _activeItemAt(_incomingItems, index);
 
     if (outgoingItem != null) {
+      if (_items[index] == null) return const SizedBox.shrink();
+      
       final child = _items[index]!.widget;
       return _removeItemBuilder(outgoingItem, child);
     }


### PR DESCRIPTION
There were some rebuilds for which this error was being throw, as the `index` was just one outside the the range of `_items`. I could not make a minimal reproducible example of this, but it would break the whole view because of this.
But checking for null and handling it fixed it for me