### PR TITLE
Add addDragStartListener flag to enable custom drag handles with ReorderableGridDragStartListener

### DIFF
--- a/lib/animated_reorderable_list.dart
+++ b/lib/animated_reorderable_list.dart
@@ -8,3 +8,6 @@ export 'src/animated_reorderable_listview.dart';
 
 //Direct access to the sliver builder, circumventing the ScrollView layer
 export 'src/builder/reorderable_animated_list_impl.dart';
+//Direct access to the ReorderableGridDragStartListener, if required when
+//addDragStartListener false
+export 'src/component/drag_listener.dart';

--- a/lib/src/animated_gridview.dart
+++ b/lib/src/animated_gridview.dart
@@ -286,6 +286,26 @@ class AnimatedGridView<E extends Object> extends StatefulWidget {
   /// Defaults to true.
   final bool enableSwap;
 
+  /// Whether to add a [ReorderableGridDragStartListener] to the reorderable ItemBuilder.
+  /// 
+  /// Defaults to true.
+  /// 
+  /// If set to false, the items in ItemBuilder will not respond to pointer down events,
+  /// which means they won't be draggable. This can be useful if you still want to
+  /// receive item pointer events, and add your custom drag start listener
+  /// to the item widget.
+  /// 
+  /// Example:
+  /// ```dart
+  /// ReorderableGridDragStartListener(
+  ///   index: dragIndex,
+  ///   child: const Icon(
+  ///     Icons.drag_handle_outlined,
+  ///   ),
+  /// ),
+  /// ```
+  final bool addDragStartListener;
+
   /// Creates a [AnimatedGridView] that animates insertion and removal of the item.
   const AnimatedGridView(
       {Key? key,
@@ -311,7 +331,8 @@ class AnimatedGridView<E extends Object> extends StatefulWidget {
       this.removeItemBuilder,
       this.shrinkWrap = false,
       required this.isSameItem,
-      this.enableSwap = true})
+      this.enableSwap = true,
+      this.addDragStartListener = true})
       : super(key: key);
 
   /// The state from the closest instance of this class that encloses the given
@@ -392,7 +413,8 @@ class AnimatedGridViewState<E extends Object>
                 insertItemBuilder: widget.insertItemBuilder,
                 removeItemBuilder: widget.removeItemBuilder,
                 isSameItem: widget.isSameItem,
-                enableSwap: widget.enableSwap),
+                enableSwap: widget.enableSwap,
+                addDragStartListener: widget.addDragStartListener),
           ),
         ]);
   }

--- a/lib/src/animated_listview.dart
+++ b/lib/src/animated_listview.dart
@@ -283,6 +283,26 @@ class AnimatedListView<E extends Object> extends StatefulWidget {
   /// Defaults to true.
   final bool enableSwap;
 
+  /// Whether to add a [ReorderableGridDragStartListener] to the reorderable ItemBuilder.
+  /// 
+  /// Defaults to true.
+  /// 
+  /// If set to false, the items in ItemBuilder will not respond to pointer down events,
+  /// which means they won't be draggable. This can be useful if you still want to
+  /// receive item pointer events, and add your custom drag start listener
+  /// to the item widget.
+  /// 
+  /// Example:
+  /// ```dart
+  /// ReorderableGridDragStartListener(
+  ///   index: dragIndex,
+  ///   child: const Icon(
+  ///     Icons.drag_handle_outlined,
+  ///   ),
+  /// ),
+  /// ```
+  final bool addDragStartListener;
+
   /// Creates a [AnimatedListView] that animates insertion and removal of the item.
   const AnimatedListView({
     Key? key,
@@ -308,6 +328,7 @@ class AnimatedListView<E extends Object> extends StatefulWidget {
     this.shrinkWrap = false,
     required this.isSameItem,
     this.enableSwap = true,
+    this.addDragStartListener = true,
   }) : super(key: key);
 
   /// The state from the closest instance of this class that encloses the given
@@ -388,6 +409,7 @@ class AnimatedListViewState<E extends Object>
               removeItemBuilder: widget.removeItemBuilder,
               isSameItem: widget.isSameItem,
               enableSwap: widget.enableSwap,
+              addDragStartListener: widget.addDragStartListener,
             ),
           ),
         ]);

--- a/lib/src/animated_reorderable_gridview.dart
+++ b/lib/src/animated_reorderable_gridview.dart
@@ -347,6 +347,26 @@ class AnimatedReorderableGridView<E extends Object> extends StatefulWidget {
   /// Defaults to true.
   final bool enableSwap;
 
+  /// Whether to add a [ReorderableGridDragStartListener] to the reorderable ItemBuilder.
+  /// 
+  /// Defaults to true.
+  /// 
+  /// If set to false, the items in ItemBuilder will not respond to pointer down events,
+  /// which means they won't be draggable. This can be useful if you still want to
+  /// receive item pointer events, and add your custom drag start listener
+  /// to the item widget.
+  /// 
+  /// Example:
+  /// ```dart
+  /// ReorderableGridDragStartListener(
+  ///   index: dragIndex,
+  ///   child: const Icon(
+  ///     Icons.drag_handle_outlined,
+  ///   ),
+  /// ),
+  /// ```
+  final bool addDragStartListener;
+
   /// Creates a [AnimatedReorderableGridView] that enables users to interactively reorder items through dragging,
   /// with animated insertion and removal of items.
   const AnimatedReorderableGridView(
@@ -381,7 +401,8 @@ class AnimatedReorderableGridView<E extends Object> extends StatefulWidget {
       this.dragStartDelay = const Duration(milliseconds: 500),
       this.nonDraggableItems = const [],
       this.lockedItems = const [],
-      this.enableSwap = true})
+      this.enableSwap = true,
+      this.addDragStartListener = true})
       : super(key: key);
 
   /// The state from the closest instance of this class that encloses the given
@@ -473,6 +494,7 @@ class AnimatedReorderableGridViewState<E extends Object>
               nonDraggableItems: widget.nonDraggableItems,
               lockedItems: widget.lockedItems,
               enableSwap: widget.enableSwap,
+              addDragStartListener: widget.addDragStartListener,
             ),
           ),
         ]);

--- a/lib/src/animated_reorderable_listview.dart
+++ b/lib/src/animated_reorderable_listview.dart
@@ -365,6 +365,26 @@ class AnimatedReorderableListView<E extends Object> extends StatefulWidget {
   /// Defaults to true.
   final bool enableSwap;
 
+  /// Whether to add a [ReorderableGridDragStartListener] to the reorderable ItemBuilder.
+  /// 
+  /// Defaults to true.
+  /// 
+  /// If set to false, the items in ItemBuilder will not respond to pointer down events,
+  /// which means they won't be draggable. This can be useful if you still want to
+  /// receive item pointer events, and add your custom drag start listener
+  /// to the item widget.
+  /// 
+  /// Example:
+  /// ```dart
+  /// ReorderableGridDragStartListener(
+  ///   index: dragIndex,
+  ///   child: const Icon(
+  ///     Icons.drag_handle_outlined,
+  ///   ),
+  /// ),
+  /// ```
+  final bool addDragStartListener;
+
   /// Creates a [AnimatedReorderableListView] that enables users to interactively reorder items through dragging,
   /// with animated insertion and removal of items.
   const AnimatedReorderableListView({
@@ -400,6 +420,7 @@ class AnimatedReorderableListView<E extends Object> extends StatefulWidget {
     this.nonDraggableItems = const [],
     this.lockedItems = const [],
     this.enableSwap = true,
+    this.addDragStartListener = true,
   }) : super(key: key);
 
   /// The state from the closest instance of this class that encloses the given
@@ -491,6 +512,7 @@ class AnimatedReorderableListViewState<E extends Object>
               nonDraggableItems: widget.nonDraggableItems,
               lockedItems: widget.lockedItems,
               enableSwap: widget.enableSwap,
+              addDragStartListener: widget.addDragStartListener,
             ),
           ),
         ]);

--- a/lib/src/builder/reorderable_animated_builder.dart
+++ b/lib/src/builder/reorderable_animated_builder.dart
@@ -32,6 +32,7 @@ class ReorderableAnimatedBuilder<E> extends StatefulWidget {
   final Duration dragStartDelay;
   final List<int> nonDraggableIndices;
   final List<int> lockedIndices;
+  final bool addDragStartListener;
 
   const ReorderableAnimatedBuilder(
       {Key? key,
@@ -49,7 +50,8 @@ class ReorderableAnimatedBuilder<E> extends StatefulWidget {
       this.longPressDraggable = false,
       required this.dragStartDelay,
       required this.nonDraggableIndices,
-      required this.lockedIndices})
+      required this.lockedIndices,
+      required this.addDragStartListener})
       : assert(initialCount >= 0),
         super(key: key);
 
@@ -848,6 +850,14 @@ class ReorderableAnimatedBuilderState extends State<ReorderableAnimatedBuilder>
       return true;
     }());
     final Key itemGlobalKey = _MotionBuilderItemGlobalKey(item.key!, this);
+
+    if (!widget.addDragStartListener) {
+      return SizedBox(
+        key: itemGlobalKey,
+        child: itemWithSemantics,
+      );
+    }
+
     if (widget.buildDefaultDragHandles) {
       switch (Theme.of(context).platform) {
         case TargetPlatform.linux:

--- a/lib/src/builder/reorderable_animated_list_base.dart
+++ b/lib/src/builder/reorderable_animated_list_base.dart
@@ -38,6 +38,7 @@ abstract class ReorderableAnimatedListBase<W extends Widget, E extends Object>
   final List<E> nonDraggableItems;
   final List<E> lockedItems;
   final bool enableSwap;
+  final bool addDragStartListener;
 
   const ReorderableAnimatedListBase(
       {Key? key,
@@ -61,7 +62,8 @@ abstract class ReorderableAnimatedListBase<W extends Widget, E extends Object>
       this.dragStartDelay,
       this.enableSwap = true,
       required this.nonDraggableItems,
-      required this.lockedItems})
+      required this.lockedItems,
+      this.addDragStartListener = true})
       : assert(itemBuilder != null),
         super(key: key);
 }
@@ -178,6 +180,10 @@ abstract class ReorderableAnimatedListBaseState<
       })
       .map((entry) => entry.key)
       .toList();
+
+  @nonVirtual
+  @protected
+  bool get addDragStartListener => widget.addDragStartListener;
 
   @override
   void initState() {

--- a/lib/src/builder/reorderable_animated_list_impl.dart
+++ b/lib/src/builder/reorderable_animated_list_impl.dart
@@ -28,6 +28,7 @@ class ReorderableAnimatedListImpl<E extends Object>
     List<E> nonDraggableItems = const [],
     List<E> lockedItems = const [],
     bool enableSwap = true,
+    bool addDragStartListener = true,
   }) : super(
             key: key,
             items: items,
@@ -49,7 +50,8 @@ class ReorderableAnimatedListImpl<E extends Object>
             dragStartDelay: dragStartDelay,
             nonDraggableItems: nonDraggableItems,
             lockedItems: lockedItems,
-            enableSwap: enableSwap);
+            enableSwap: enableSwap,
+            addDragStartListener: addDragStartListener);
 
   const ReorderableAnimatedListImpl.grid({
     Key? key,
@@ -74,6 +76,7 @@ class ReorderableAnimatedListImpl<E extends Object>
     List<E> nonDraggableItems = const [],
     List<E> lockedItems = const [],
     bool enableSwap = true,
+    bool addDragStartListener = true,
   }) : super(
             key: key,
             items: items,
@@ -96,7 +99,8 @@ class ReorderableAnimatedListImpl<E extends Object>
             dragStartDelay: dragStartDelay,
             nonDraggableItems: nonDraggableItems,
             lockedItems: lockedItems,
-            enableSwap: enableSwap);
+            enableSwap: enableSwap,
+            addDragStartListener: addDragStartListener);
 
   @override
   ReorderableAnimatedListImplState<E> createState() =>
@@ -127,6 +131,7 @@ class ReorderableAnimatedListImplState<E extends Object>
       dragStartDelay: dragStartDelay,
       nonDraggableIndices: nonDraggableItems,
       lockedIndices: lockedIndices,
+      addDragStartListener: addDragStartListener,
     );
   }
 }


### PR DESCRIPTION
This PR introduces a new boolean property, `addDragStartListener`. When set to `false`, the `ReorderableGridDragStartListener` will *not* be injected, allowing to listen to item builder children tap events and wrap own widgets (e.g. a “burger” icon) with `ReorderableGridDragStartListener` at any desired location inside item builder, which can be used to edit list order.

This closes the issue #132 requesting support for custom drag handles:

> *“Please provide a way to use `ReorderableGridDragStartListener` with custom widget, … when by design we want to drag only with specific burger icon instead of full item widget.”*

**Changes:**

* **New API**

  ```dart
  /// Whether to add a [ReorderableGridDragStartListener] to the reorderable ItemBuilder.
  /// 
  /// Defaults to true.
  /// 
  /// If set to false, the items in ItemBuilder will not respond to pointer down events,
  /// which means they won't be draggable. This can be useful if you still want to
  /// receive item pointer events, and add your custom drag start listener
  /// to the item widget.
  /// 
  /// Example:
  /// ```dart
  /// ReorderableGridDragStartListener(
  ///   index: dragIndex,
  ///   child: const Icon(
  ///     Icons.drag_handle_outlined,
  ///   ),
  /// ),
  /// ```
  final bool addDragStartListener;
  ```
* **Constructor default**:
  Sets `addDragStartListener = true` to preserve existing behavior.
* **`reorderableItemBuilder`**:

  * If `addDragStartListener == false`, simply returns the item, without `ReorderableGridDragStartListener`.
  * Otherwise, retains existing logic, whole item is draggable.

**Usage Example:**

```dart
AnimatedReorderableListView(
  items: items,
  addDragStartListener: false, // disable drag listener
  itemBuilder: (context, index) {
    final item = items[index];
    return ListTile(
      title: Text(item.title),
      onTap: () {
        // Handle item tap, if needed
      },
      trailing: ReorderableGridDragStartListener(
        index: index,
        child: Icon(Icons.drag_handle), // custom handle
      ),
    );
  },
  onReorder: (int oldIndex, int newIndex) {
    setState(() {
      final item = items.removeAt(oldIndex);
      items.insert(newIndex, item);
    });
   },
   isSameItem: (a, b) => a.id == b.id,
);
```

### Local Testing / Preview

*To try out this PR, point your `pubspec.yaml` at the Git branch:*

```yaml
dependency_overrides:
  animated_reorderable_list:
    git:
      url: https://github.com/shebnik/animated_reorderable_list.git
      ref: fix-item-tap
```